### PR TITLE
Fixed fast voigt and GNU support

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ FOR  = ifort
 FFLAGS =  -O3 -qopenmp -traceback  -ip 
 
 #FOR = gfortran
-#FFLAGS = -O2 -fopenmp -std=f2008
+#FFLAGS = -O3 -fopenmp -std=f2008 -ffree-line-length-512
 
 
 #FFLAGS = -O0 -g -fpe0  -fltconsistency -stand f03 -check all -warn all -traceback -fp-stack-check  # debugging options

--- a/spectrum.f90
+++ b/spectrum.f90
@@ -1905,7 +1905,7 @@ module spectrum
       write(out,"(10x,'Pressure = ',e18.7)") pressure
       write(out,"(10x,'Voigt parameters:   gamma       n         T0            P0     Ratio')")
       do i =1,Nspecies
-        write(out,"(21x,a,4f12.4,1xf13.6)") trim(species(i)%name),species(i)%gamma,species(i)%n,species(i)%t0,species(i)%p0,species(i)%ratio
+        write(out,"(21x,a,4f12.4,f13.6)") trim(species(i)%name),species(i)%gamma,species(i)%n,species(i)%t0,species(i)%p0,species(i)%ratio
       enddo
    endif
    !

--- a/spectrum.f90
+++ b/spectrum.f90
@@ -1810,7 +1810,7 @@ module spectrum
    gamma_comb = -1
    do i=0,JmaxAll
      do j= max(0,i-2),min(JmaxAll,i+2)
-      gamma_comb(j,i-j) = get_Voigt_gamma_val(Nspecies,real(i,rk),real(j,rk))
+      gamma_comb(i,i-j) = get_Voigt_gamma_val(Nspecies,real(i,rk),real(j,rk))
      enddo
    enddo
    !


### PR DESCRIPTION
So I found the bug....8 hours and it turns out to be a tiny index change. Took a while as I had to relearn FORTRAN again recently and the macos gdb is trash haha (kill me). The KCL test works now. At least I learnt how to trap nans and find them in the debugger.

Anyway I also added some extra flags for gfortran compatibility